### PR TITLE
 Make the sbd disk shareable

### DIFF
--- a/libvirt/terraform/modules/host/main.tf
+++ b/libvirt/terraform/modules/host/main.tf
@@ -30,6 +30,11 @@ resource "libvirt_domain" "domain" {
   count = "${var.count}"
   qemu_agent = true
 
+  // use xslt to configure the sbd disk as shareable.
+    xml {
+    xslt = "${file("./modules/host/shareable.xsl")}"
+  }
+
   // base disk + additional disks if any
   disk = ["${concat(
     list(

--- a/libvirt/terraform/modules/host/shareable.xsl
+++ b/libvirt/terraform/modules/host/shareable.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:template match="node()|@*">
+     <xsl:copy>
+       <xsl:apply-templates select="node()|@*"/>
+     </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/domain/devices/disk/source">
+      <xsl:copy>
+          <xsl:apply-templates select="@* | node()"/>
+      </xsl:copy>  
+          <xsl:if test="contains(./@volume,'sbd')">
+              <xsl:element name="shareable"/>    
+           </xsl:if> 
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Uses XSLT to edit the libvirt XML and inject shareable tag for the SBD
disk.